### PR TITLE
fix add close curly braces of Vue Watchers

### DIFF
--- a/snippets/vue.json
+++ b/snippets/vue.json
@@ -218,7 +218,7 @@
 		"prefix": "vwatcher",
 		"body": [
 			"watch: {",
-			"\t${1:data}(${2:newValue, ${3:oldValue) {",
+			"\t${1:data}(${2:newValue}, ${3:oldValue}) {",
 			"\t\t${0}",
 			"\t}",
 			"},"


### PR DESCRIPTION
I found a "Vue Watchers"'s bug.
I added close curly braces.
would you please check this?