### PR TITLE
Make snippets available in JS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
             {
                 "language": "plaintext",
                 "path": "./snippets/plaintext.json"
+            },
+            {
+                "language": "javascript",
+                "path": "./snippets/vue.json"
             }
         ]
     }


### PR DESCRIPTION
Personally, when `.vue` files start getting too large, I break the CSS & JS into separate files and import them. This change just makes the snippets available in files with `.js` file extension.