### PR TITLE
Fix vprops "Number" type

### DIFF
--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -36,7 +36,7 @@
     "body": [
       "props: {",
       "\t${1:propName}: {",
-      "\t\ttype: ${2:number},",
+      "\t\ttype: ${2:Number},",
       "\t\tdefault: ${0}",
       "\t},",
       "},"


### PR DESCRIPTION
`vprops` uses `number` as the default type instead of the correct `Number`.

Although default types are probably changed by the user anyway, an actually working default should be preferrable. 🙂