### PR TITLE
Change vimport-c to vcomponents

### DIFF
--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -49,7 +49,7 @@
     "description": "Import one component into another"
   },
   "Vue Import into the Component": {
-    "prefix": "vimport-c",
+    "prefix": "vcomponents",
     "body": ["components: {", "\t${1:New},", "}"],
     "description": "Import one component into another, within export statement"
   },


### PR DESCRIPTION
Change to allow the components property to follow the same syntax as the other within-script snippets. vimport-c is unintuitive to create a components property, especially when all the other properties are created with v<<property>>