### PR TITLE
Escaping $ characters and changed vimport-c to vcomponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | `vwatcher`       | Vue watcher with new and old value args                                  |
 | `vprops`         | Props with type and default                                              |
 | `vimport`        | Import one component into another                                        |
-| `vimport-c`      | Import one component into another within the export statement            |
+| `vcomponents`    | Import one component into another within the export statement            |
 | `vimport-export` | Import one component into another and use it within the export statement |
 | `vfilter`        | Vue filter                                                               |
 | `vmixin`         | Create a Vue Mixin                                                       |

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "displayName": "Vue VSCode Snippets",
   "description": "Snippets that will supercharge your Vue workflow",
   "icon": "images/vue-logo.png",
-  "version": "1.3.0",
-  "publisher": "sdras",
+  "version": "1.3.1",
+  "publisher": "johnpyp",
   "engines": {
     "vscode": "^1.14.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "displayName": "Vue VSCode Snippets",
   "description": "Snippets that will supercharge your Vue workflow",
   "icon": "images/vue-logo.png",
-  "version": "1.3.1",
-  "publisher": "johnpyp",
+  "version": "1.3.0",
+  "publisher": "sdras",
   "engines": {
     "vscode": "^1.14.0"
   },

--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -14,7 +14,7 @@
     "body": [
       "computed: {",
       "\t${1:name}() {",
-      "\t\treturn this.${2:data} ${0}",
+      "\t\treturn this.\\${2:data} ${0}",
       "\t}",
       "},"
     ],
@@ -49,7 +49,7 @@
     "description": "Import one component into another"
   },
   "Vue Import into the Component": {
-    "prefix": "vimport-c",
+    "prefix": "vcomponents",
     "body": ["components: {", "\t${1:New},", "}"],
     "description": "Import one component into another, within export statement"
   },
@@ -139,7 +139,7 @@
     "prefix": "vcommit",
     "body": [
       "${1:mutationName}() {",
-      "\tthis.\$store.commit('${1:mutationName}', ${2:payload})",
+      "\tthis.\\$store.commit('${1:mutationName}', ${2:payload})",
       "}"
     ],
     "description": "commit to vuex store in methods for mutation"
@@ -148,7 +148,7 @@
     "prefix": "vdispatch",
     "body": [
       "${1:actionName}() {",
-      "\tthis.$store.dispatch('${1:actionName}', ${2:payload})",
+      "\tthis.\\$store.dispatch('${1:actionName}', ${2:payload})",
       "}"
     ],
     "description": "dispatch to vuex store in methods for action"

--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -139,7 +139,7 @@
     "prefix": "vcommit",
     "body": [
       "${1:mutationName}() {",
-      "\tthis.$store.commit('${1:mutationName}', ${2:payload})",
+      "\tthis.\$store.commit('${1:mutationName}', ${2:payload})",
       "}"
     ],
     "description": "commit to vuex store in methods for mutation"


### PR DESCRIPTION
- Escaped $ characters (ex this.$store). In the live version these characters aren't printed as they are special to vscode

- Changed vimport-c to vcomponents to improve clarity of what it does and make it more intuitive for people to find it as it follows other script property syntax