### PR TITLE
add Template snaippet v-for with index

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | Snippet           | Purpose                             |
 | ----------------- | ----------------------------------- |
 | `vfor`            | v-for directive                     |
+| `vfori`           | v-for directive with index          |
 | `vmodel`          | Semantic v-model directive          |
 | `vmodel-num`      | Semantic v-model number directive   |
 | `von`             | v-on click handler with arguments   |

--- a/snippets/vue-template.json
+++ b/snippets/vue-template.json
@@ -8,6 +8,15 @@
     ],
     "description": "vfor statement"
   },
+  "Vue v-for with index": {
+    "prefix": "vfori",
+    "body": [
+      "<${1:div} v-for=\"(${2:item}, ${3:i}) in ${2:item}s\" :key=\"${3:i}\">",
+      "\t{{ ${2:item} }}",
+      "</${1:div}>"
+    ],
+    "description": "vfor statement with index"
+  },
   "Vue v-model Directive": {
     "prefix": "vmodel",
     "body": ["<input v-model=\"${1:data}\" type=\"text\" />"],


### PR DESCRIPTION
Hi, i am a Vue coder and i am very happy to find this VsCode extension, it will help me efficiently  write Vue code in my daily.
I often write the code like below:
```
<div v-for="(item, i) in items" :key="i">
      {{ item }}
</div>
```
I think the snippet vfori will useful when the ViewModel without the id attributes. 
It's my first time to contribute code in open source , waiting for your reply.