### PR TITLE
Add snippets for pug templates

### DIFF
--- a/snippets/vue-pug.json
+++ b/snippets/vue-pug.json
@@ -1,0 +1,86 @@
+{
+  "Vue v-for": {
+    "prefix": "vfor",
+    "body": [
+      "${1:div}(v-for=\"${2:item} in ${2:item}s\" :key=\"${2:item}.id\")",
+      "\t| {{ ${2:item} }}"
+    ],
+    "description": "vfor statement"
+  },
+  "Vue v-model Directive": {
+    "prefix": "vmodel",
+    "body": ["input(v-model=\"${1:data}\" type=\"text\")"],
+    "description": "v-model directive"
+  },
+  "Vue v-model Number Directive": {
+    "prefix": "vmodel-num",
+    "body": [
+      "input(v-model.number=\"${1:numData}\" type=\"number\" step=\"1\")"
+    ],
+    "description": "v-model directive number input"
+  },
+  "Vue v-on Shortcut Directive": {
+    "prefix": "von",
+    "body": ["@click=\"${1:handler}(${2:arg}, $event)\""],
+    "description": "v-on click handler with arguments"
+  },
+  "Vue Component with Props Binding": {
+    "prefix": "vel-props",
+    "body": ["${1:component}(:${1:propName}=\"${0}\")"],
+    "description": "component element with props"
+  },
+  "Vue Image Source Binding": {
+    "prefix": "vsrc",
+    "body": [
+      "img(:src=\"'/path/to/images/' + ${1:fileName}\" alt=\"${2:altText}\")"
+    ],
+    "description": "image source binding"
+  },
+  "Vue Style Binding": {
+    "prefix": "vstyle",
+    "body": ["${1:div}(:style=\"{ fontSize: ${2:data} + 'px' }\")"],
+    "description": "vue inline style binding"
+  },
+  "Vue Style Binding Object": {
+    "prefix": "vstyle-obj",
+    "body": ["${1:div}(:style=\"[${2:styleObjectA}, ${3:styleObjectB]}\")"],
+    "description": "vue inline style binding, objects"
+  },
+  "Vue Class Binding": {
+    "prefix": "vclass",
+    "body": ["${1:div}(:class=\"{ ${2:className}: ${3:data} }\")"],
+    "description": "vue class binding"
+  },
+  "Vue Class Binding Object": {
+    "prefix": "vclass-obj",
+    "body": ["${1:div}(:class=\"[${2:classNameA}, ${3:classNameB}]\")"],
+    "description": "vue class binding"
+  },
+  "Vue Multiple Conditional Class Bindings": {
+    "prefix": "vclass-obj-mult",
+    "body": [
+      "${1:div}(:class=\"[${2:classNameA}, {${3:classNameB} : ${4:condition}}]\")"
+    ],
+    "description": "vue multiple conditional class bindings"
+  },
+  "Vue Transition Component with JavaScript Hooks": {
+    "prefix": "vanim",
+    "body": [
+      "transition(",
+      "\tmode=\"out-in\"",
+      "\t@before-enter=\"beforeEnter\"",
+      "\t@enter=\"enter\"",
+      "",
+      "\t@before-leave=\"beforeLeave\"",
+      "\t@leave=\"leave\"",
+      "\t:css=\"false\"",
+      ")"
+    ],
+    "description": "transition component js hooks"
+  },
+  "Vue Nuxt Routing Link": {
+    "prefix": "vnuxtl",
+    "body": ["nuxt-link(to=\"/${1:page}\") ${1:page}"],
+    "description": "nuxt routing link"
+  }
+}


### PR DESCRIPTION
Hey! 
Love this extension, but haven't been able to use the template snippets on projects that use pug. This PR adds those pug template snippets (same snippets currently used in `vue-template.json`) in case you think others might benefit from it!

