### PR TITLE
make CSS the vbase default style

### DIFF
--- a/snippets/vue.json
+++ b/snippets/vue.json
@@ -14,7 +14,7 @@
 			"\t}",
 			"</script>",
 			"",
-			"<style lang=\"scss\" scoped>",
+			"<style scoped>",
 			"",
 			"</style>"
 		],
@@ -32,7 +32,7 @@
 			"<script lang=\"ts\">",
 			"\timport Vue from 'vue'",
 			"",
-        	"\texport default Vue.extend({",
+			"\texport default Vue.extend({",
 			"\t\t${0}",
 			"\t})",
 			"</script>",
@@ -44,4 +44,3 @@
 		"description": "Base for Vue File with Typescript"
 	}
 }
-


### PR DESCRIPTION
I keep on removing the lang="scss", so I thought I might not be the only one.
I also saw that in your small Demo, it is not there either.