### PR TITLE
Added v-base-pug for PUG language

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | `vbase-css` | Single file component base with CSS        |
 | `vbase-pcss`| Single file component base with PostCSS    |
 | `vbase-ts`  | Single file component base with Typescript |
-| `vbase-pug`  | Single file component base with Pug        |
+| `vbase-pug` | Single file component base with Pug        |
 
 ### Template
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | `vbase-css` | Single file component base with CSS        |
 | `vbase-pcss`| Single file component base with PostCSS    |
 | `vbase-ts`  | Single file component base with Typescript |
+| `vbase-pug`  | Single file component base with Pug        |
 
 ### Template
 

--- a/snippets/vue.json
+++ b/snippets/vue.json
@@ -84,6 +84,27 @@
 			"</style>"
 		],
 		"description": "Base for Vue File with Typescript"
+	},
+	"Vue Single File Component with Pug": {
+		"prefix": "vbase-pug",
+		"body": [
+			"<template lang=\"pug\">",
+			"\t<div>",
+			"",
+			"\t</div>",
+			"</template>",
+			"",
+			"<script>",
+			"\texport default {",
+			"\t\t${0}",
+			"\t}",
+			"</script>",
+			"",
+			"<style lang=\"scss\" scoped>",
+			"",
+			"</style>"
+		],
+		"description": "Base for Vue File with Pug and SCSS"
 	}
 }
 

--- a/snippets/vue.json
+++ b/snippets/vue.json
@@ -89,9 +89,7 @@
 		"prefix": "vbase-pug",
 		"body": [
 			"<template lang=\"pug\">",
-			"\t<div>",
-			"",
-			"\t</div>",
+			"\tdiv",
 			"</template>",
 			"",
 			"<script>",


### PR DESCRIPTION
##  Description and Issue

I'm a true fan of these snippets. Huge thanks for @sdras who brings in these snippets to Vue community. But since I'm mostly writing my templates with PUG language, I've discovered that I was changing template's language after using `vbase` when I create a new `.vue` file. I know there are people like me who loves write pug therefore I wanted to make a little contribute for that amazing project.

## Changes made

`vbase-pug` snippet added into `vue.json` file which uses `.scss` as style language and description added into `README.md` file. 