### PR TITLE
Remove reference to plaintext.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,10 +72,6 @@
       {
         "language": "typescript",
         "path": "./snippets/nuxt-config.json"
-      },
-      {
-        "language": "plaintext",
-        "path": "./snippets/plaintext.json"
       }
     ]
   }


### PR DESCRIPTION
I'm using this extension in Neovim with [coc-snippets](https://github.com/neoclide/coc-snippets). After installing, I get this error:

`[coc.nvim] Error on load snippets: ENOENT: no such file or directory, open '/Users/joshukraine/.config/coc/extensions/node_modules/vue-vscode-snippets/snippets/plaintext.json'`

I believe `snippets/plaintext.json` was renamed in this commit: https://github.com/sdras/vue-vscode-snippets/commit/499f5ef35d1a1c066fcdd5207d4f02e2bcaacba7

Removing the reference in package.json resolves the error.

Thank you for these great snippets! 🙂👍🏻