### PR TITLE
feat(vue3) add composition api

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | `vdec`           | decrementer                                                              |
 | `vconfig`        | vue.config.js file, example imports a sass file into every component     |
 
+### Vue Composition API
+
+| Snippet           | Purpose                                            |
+| ----------------- | -------------------------------------------------- |
+| v3reactive        | Vue Composition api - reactive                     |
+| v3computed        | Vue Composition api - computed                     |
+| v3watch           | Vue Composition api - watcher single source        |
+| v3watch-array     | Vue Composition api - watch as array               |
+| v3watcheffect     | Vue Composition api - watchEffect                  |
+| v3ref             | Vue Ref                                            |
+| v3onmounted       | Lifecycle hook - onMounted                         |
+| v3onbeforemount   | Lifecycle hook - onBeforeMount                     |
+| v3onbeforeupdate  | Lifecycle hook - onBeforeUpdate                    |
+| v3onupdated       | Lifecycle hook - onUpdated                         |
+| v3onerrorcaptured | Lifecycle hook - onErrorCaptured                   |
+| v3onunmounted     | Lifecycle hook - (destroyed) onUnmounted           |
+| v3onbeforeunmount | Lifecycle hook - (beforeDestroy) onBeforeUnmount   |
+
 ### Vuex
 
 | Snippet         | Purpose                        |

--- a/README.md
+++ b/README.md
@@ -32,16 +32,18 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 
 ### Vue
 
-| Snippet      | Purpose                                    |
-| ------------ | ------------------------------------------ |
-| `vbase`      | Single file component base with SCSS       |
-| `vbase-css`  | Single file component base with CSS        |
-| `vbase-pcss` | Single file component base with PostCSS    |
-| `vbase-styl` | Single file component base with Stylus     |
-| `vbase-ts`   | Single file component base with Typescript |
-| `vbase-ns`   | Single file component with no styles       |
-| `vbase-sass` | Single file component base with SASS       |
-| `vbase-less` | Single file component base with LESS       |
+| Snippet      | Purpose                                               |
+| ------------ | ----------------------------------------------------- |
+| `vbase`      | Single file component base with SCSS                  |
+| `vbase-3`    | Single File component Composition API with SCSS       |
+| `vbase-css`  | Single file component base with CSS                   |
+| `vbase-pcss` | Single file component base with PostCSS               |
+| `vbase-styl` | Single file component base with Stylus                |
+| `vbase-ts`   | Single file component base with Typescript            |
+| `vbase-3-ts` | Single File component Composition API with Typescript |
+| `vbase-ns`   | Single file component with no styles                  |
+| `vbase-sass` | Single file component base with SASS                  |
+| `vbase-less` | Single file component base with LESS                  |
 
 ### Template
 

--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -316,7 +316,7 @@
       "\t${2:count}: ${3:0}",
       "})"
     ],
-    "description": "Vue Composition api - computed"
+    "description": "Vue Composition api - reactive"
   },
   "Vue Composition API - Computed": {
     "prefix": "v3computed",
@@ -334,7 +334,7 @@
       "\t${2}",
       "})"
     ],
-    "description": "Vue Composition api - watch as array"
+    "description": "Vue Composition api - watcher single source"
   },
   "Vue Composition API - watch - array": {
     "prefix": "v3watch-array",

--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -308,5 +308,90 @@
       "}"
     ],
     "description": "vue.config.js"
+  },
+  "Vue Composition API - Reactive": {
+    "prefix": "v3reactive",
+    "body": [
+      "const ${1:name} = reactive({",
+      "\t${2:count}: ${3:0}",
+      "})"
+    ],
+    "description": "Vue Composition api - computed"
+  },
+  "Vue Composition API - Computed": {
+    "prefix": "v3computed",
+    "body": [
+      "const ${1:name} = computed(() => {",
+      "\treturn ${2}",
+      "})"
+    ],
+    "description": "Vue Composition api - computed"
+  },
+  "Vue Composition API - watch - single source": {
+    "prefix": "v3watch",
+    "body": [
+      "watch(() => ${1:foo}, (newValue, oldValue) => {",
+      "\t${2}",
+      "})"
+    ],
+    "description": "Vue Composition api - watch as array"
+  },
+  "Vue Composition API - watch - array": {
+    "prefix": "v3watch-array",
+    "body": [
+      "watch([${1:foo}, ${2:bar}], ([new${1}, new${2}], [prev${1}, prev${2}]) => {",
+      "\t${3}",
+      "})"
+    ],
+    "description": "Vue Composition api - watch as array"
+  },
+  "Vue Composition API - watchEffect": {
+    "prefix": "v3watcheffect",
+    "body": [
+      "watchEffect(() => {",
+      "\t${1}",
+      "})"
+    ],
+    "description": "Vue Composition api - watchEffect"
+  },
+  "Vue Composition API - Vue ref": {
+    "prefix": "v3ref",
+    "body": ["const ${1:name} = ref(${2:initialValue})"],
+    "description": "Vue Ref"
+  },
+  "Vue Lifecycle Hooks - onMounted": {
+    "prefix": "v3onmounted",
+    "body": ["onMounted(() => {${1}})"],
+    "description": "Vue Mounted Lifecycle hook"
+  },
+  "Vue Lifecycle Hooks - onBeforeMount": {
+    "prefix": "v3onbeforemount",
+    "body": ["onBeforeMount(() => {${1}})"],
+    "description": "Vue onBeforeMount Lifecycle hook"
+  },
+  "Vue Lifecycle Hooks - onBeforeUpdate": {
+    "prefix": "v3onbeforeupdate",
+    "body": ["onBeforeUpdate(() => {${1}})"],
+    "description": "Vue onBeforeUpdate Lifecycle hook"
+  },
+  "Vue Lifecycle Hooks - onUpdated": {
+    "prefix": "v3onupdated",
+    "body": ["onUpdated(() => {${1}})"],
+    "description": "Vue onUpdated Lifecycle hook"
+  },
+  "Vue Lifecycle Hooks - onErrorCaptured": {
+    "prefix": "v3onerrorcaptured",
+    "body": ["onErrorCaptured(() => {${1}})"],
+    "description": "Vue onErrorCaptured Lifecycle hook"
+  },
+  "Vue Lifecycle Hooks - onUnmounted": {
+    "prefix": "v3onunmounted",
+    "body": ["onUnmounted(() => {${1}})"],
+    "description": "(destroyed) Vue onUnmounted Lifecycle hook"
+  },
+  "Vue Lifecycle Hooks - onBeforeUnmount": {
+    "prefix": "v3onbeforeunmount",
+    "body": ["onBeforeUnmount(() => {${1}})"],
+    "description": "(beforeDestroy) Vue onBeforeUnmount Lifecycle hook"
   }
 }

--- a/snippets/vue.json
+++ b/snippets/vue.json
@@ -164,5 +164,56 @@
       "</script>"
     ],
     "description": "Base for Vue File with no styles"
+  },
+  "Vue Single File Component Composition API": {
+    "prefix": "vbase-3",
+    "body": [
+      "<template>",
+      "\t<div>",
+      "",
+      "\t</div>",
+      "</template>",
+      "",
+      "<script>",
+      "export default {",
+      "\tsetup () {",
+      "\t\t${0}",
+      "",
+      "\t\treturn {}",
+      "\t}",
+      "}",
+      "</script>",
+      "",
+      "<style lang=\"scss\" scoped>",
+      "",
+      "</style>"
+    ],
+    "description": "Base for Vue File Composition API with SCSS"
+  },
+  "Vue Single File Component Composition API with Typescript": {
+    "prefix": "vbase-3-ts",
+    "body": [
+      "<template>",
+      "\t<div>",
+      "",
+      "\t</div>",
+      "</template>",
+      "",
+      "<script lang=\"ts\">",
+      "import Vue from 'vue'",
+      "",
+      "export default Vue.extend({",
+      "\tsetup () {",
+      "\t\t${0}\n",
+      "\t\treturn {}",
+      "\t}",
+      "})",
+      "</script>",
+      "",
+      "<style scoped>",
+      "",
+      "</style>"
+    ],
+    "description": "Base for Vue File Composition API - Typescript"
   }
 }


### PR DESCRIPTION
This PR is for some composition api snippets. I made a call to prefix with `v3` but open for bikeshedding. The autocomplete in vscode is good enough that typing `vwatch` would still show you the v3 results.

- added v3 to all snippet prefix so that it's easier to filter e.g.:
![image](https://user-images.githubusercontent.com/5770711/81605806-0a97ea80-93a0-11ea-9e9a-465fd77d3f96.png)
- `vbase-` did not prefix with v3 because `vbase` is ingrained and so I figured it'd be helpful to give it some priority when opening a new file.

![May-11-2020 16-09-25](https://user-images.githubusercontent.com/5770711/81607010-fce36480-93a1-11ea-8446-8b2bed50a4fc.gif)

