### PR TITLE
Move emit snippets from script to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | `vroutename`      | router-link Named Routing           |
 | `vroutenameparam` | router-link Named with Parameters   |
 | `vroutepath`      | router-link Path Routing Link       |
+| `vemit-child`     | Emit event from child component     |
+| `vemit-parent`    | Emit event to parent component      |
 
 ### Script
 
@@ -86,8 +88,6 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 | `vbeforedestroy`  | beforeDestroy lifecycle method                                           |
 | `vdestroyed`      | destroyed lifecycle method                                               |
 | `vprops`          | Props with type and default                                              |
-| `vemit-child`     | Emit event from child component                                          |
-| `vemit-parent`    | Emit event tp parent component                                           |
 | `vimport`         | Import one component into another                                        |
 | `vimport-dynamic` | Import one component that should be lazy loaded by webpack               |
 | `vcomponents`     | Import one component into another within the export statement            |

--- a/snippets/vue-pug.json
+++ b/snippets/vue-pug.json
@@ -82,5 +82,15 @@
     "prefix": "vnuxtl",
     "body": ["nuxt-link(to=\"/${1:page}\") ${1:page}"],
     "description": "nuxt routing link"
+  },
+  "Vue Emit from Child": {
+    "prefix": "vemit-child",
+    "body": ["@change=\"$emit('change', $event.target.value)\""],
+    "description": "Vue Emit from Child Component"
+  },
+  "Vue Emit to Parent": {
+    "prefix": "vemit-parent",
+    "body": ["@change=\"${1:foo} = $event\""],
+    "description": "Vue Emit to Parent Component"
   }
 }

--- a/snippets/vue-script.json
+++ b/snippets/vue-script.json
@@ -98,16 +98,6 @@
     ],
     "description": "Vue Props with Default"
   },
-  "Vue Emit from Child": {
-    "prefix": "vemit-child",
-    "body": ["@change=\"$emit('change', $event.target.value)\""],
-    "description": "Vue Emit from Child Component"
-  },
-  "Vue Emit to Parent": {
-    "prefix": "vemit-parent",
-    "body": ["@change=\"${1:foo} = $event\""],
-    "description": "Vue Emit to Parent Component"
-  },
   "Vue Import File": {
     "prefix": "vimport",
     "body": ["import ${1:New} from '@/components/${1:New}.vue';"],

--- a/snippets/vue-template.json
+++ b/snippets/vue-template.json
@@ -112,5 +112,15 @@
     "prefix": "vroutepath",
     "body": ["<router-link to=\"${1:path}\">${2:LinkTitle}</router-link>"],
     "description": "Path routing link"
+  },
+  "Vue Emit from Child": {
+    "prefix": "vemit-child",
+    "body": ["@change=\"$emit('change', $event.target.value)\""],
+    "description": "Vue Emit from Child Component"
+  },
+  "Vue Emit to Parent": {
+    "prefix": "vemit-parent",
+    "body": ["@change=\"${1:foo} = $event\""],
+    "description": "Vue Emit to Parent Component"
   }
 }


### PR DESCRIPTION
I found that both the `vemit-child` and `vemit-parent` snippets can only be used in the script part of a SFC which is weird because they unfold into `@change=...` which is a template directive.

I moved them to both the template and pug snippets and also updated the documentation.

PS: Thank you so much for these snippets!