### PR TITLE
feat: remove vetur from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "Composition API",
     "Vue Snippets"
   ],
-  "extensionDependencies": [
-    "octref.vetur"
-  ],
+  "extensionDependencies": [],
   "categories": [
     "Snippets"
   ],


### PR DESCRIPTION
In Vuejs 3 we have more choice like Volar or VueDX, if nothing use from Vetur could remove it from dependencies.