### PR TITLE
add setup first snippet and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,24 @@ You can enable tab completion (recommended) by opening `Code > Preferences > Set
 
 ### Vue
 
-| Snippet            | Purpose                                                      |
-| ------------------ | ------------------------------------------------------------ |
-| `vbase`            | Single file component base with SCSS                         |
-| `vbase-3`          | Single File component Composition API with SCSS              |
-| `vbase-3-setup`    | Single File component setup Composition API with SCSS        |
-| `vbase-3-reactive` | Single File component Composition API with Reactive and SCSS |
-| `vbase-css`        | Single file component base with CSS                          |
-| `vbase-pcss`       | Single file component base with PostCSS                      |
-| `vbase-styl`       | Single file component base with Stylus                       |
-| `vbase-ts`         | Single file component base with Typescript                   |
-| `vbase-ts-class`   | Single file component base with Typescript Class Format      |
-| `vbase-3-ts`       | Single File component Composition API with Typescript        |
-| `vbase-3-ts-setup` | Single File component setup Composition API with Typescript  |
-| `vbase-ns`         | Single file component with no styles                         |
-| `vbase-sass`       | Single file component base with SASS                         |
-| `vbase-less`       | Single file component base with LESS                         |
+| Snippet                  | Purpose                                                           |
+| ------------------------ | ----------------------------------------------------------------- |
+| `vbase`                  | Single file component base with SCSS                              |
+| `vbase-3`                | Single File component Composition API with SCSS                   |
+| `vbase-3-setup`          | Single File component setup Composition API with SCSS             |
+| `vbase-3-setup-first`    | Single File component setup first Composition API with SCSS       |
+| `vbase-3-reactive`       | Single File component Composition API with Reactive and SCSS      |
+| `vbase-css`              | Single file component base with CSS                               |
+| `vbase-pcss`             | Single file component base with PostCSS                           |
+| `vbase-styl`             | Single file component base with Stylus                            |
+| `vbase-ts`               | Single file component base with Typescript                        |
+| `vbase-ts-class`         | Single file component base with Typescript Class Format           |
+| `vbase-3-ts`             | Single File component Composition API with Typescript             |
+| `vbase-3-ts-setup`       | Single File component setup Composition API with Typescript       |
+| `vbase-3-ts-setup-first` | Single File component setup first Composition API with Typescript |
+| `vbase-ns`               | Single file component with no styles                              |
+| `vbase-sass`             | Single file component base with SASS                              |
+| `vbase-less`             | Single file component base with LESS                              |
 
 ### Template
 

--- a/snippets/vue.json
+++ b/snippets/vue.json
@@ -209,6 +209,25 @@
     ],
     "description": "Base for Vue File Setup Composition API with SCSS"
   },
+  "Vue Single File Component Setup First Composition API": {
+    "prefix": "vbase-3-setup-first",
+    "body": [
+      "<script setup>",
+      "",
+      "</script>",
+      "",
+      "<template>",
+      "\t<div>",
+      "",
+      "\t</div>",
+      "</template>",
+      "",
+      "<style lang=\"scss\" scoped>",
+      "",
+      "</style>"
+    ],
+    "description": "Base for Vue File Setup First Composition API with SCSS"
+  },
   "Vue Single File Component Composition API Reactive": {
     "prefix": "vbase-3-reactive",
     "body": [
@@ -284,6 +303,25 @@
       "</style>"
     ],
     "description": "Base for Vue File Setup Composition API - Typescript"
+  },
+  "Vue Single File Component Setup First Composition API with Typescript": {
+    "prefix": "vbase-3-ts-setup-first",
+    "body": [
+      "<script setup lang=\"ts\">",
+      "",
+      "</script>",
+      "",
+      "<template>",
+      "\t<div>",
+      "",
+      "\t</div>",
+      "</template>",
+      "",
+      "<style scoped>",
+      "",
+      "</style>"
+    ],
+    "description": "Base for Vue File Setup First Composition API - Typescript"
   },
   "Vue Single File Component with Class based Typescript format": {
     "prefix": "vbase-ts-class",


### PR DESCRIPTION
Because more and more projects like [antfu/vitesse](https://github.com/antfu/vitesse) adopt script first order in Vue and eslint-plugin-vue also have "vue/component-tags-order" to limit script, template and style tag order. 
So I add `vbase-3-setup-first` and `vbase-3-ts-setup-first` snippets. Hope this can help.